### PR TITLE
feat: reward configurator popup on mission price badge

### DIFF
--- a/src/app/(home)/missions/missions-grid.tsx
+++ b/src/app/(home)/missions/missions-grid.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useMemo,
   useRef,
+  useState,
   type ComponentProps,
   type KeyboardEvent,
   type ReactNode,
@@ -20,7 +21,6 @@ import {
   DialogTrigger,
 } from '@waveso/ui/dialog';
 import { Masonry, MasonryItem } from '@waveso/ui/masonry';
-import { ScrollArea } from '@waveso/ui/scroll-area';
 import {
   Select,
   SelectContent,
@@ -46,6 +46,7 @@ import {
 } from 'lucide-react';
 import type { Mission } from '@/lib/github/fetch-missions-data';
 import { MISSIONS_PROJECT_URL } from '@/lib/github/constants';
+import { IBOX_PRICE_USD } from '@/lib/config';
 import { cn } from '@/lib/cn';
 
 type BadgeVariant = ComponentProps<typeof Badge>['variant'];
@@ -511,6 +512,93 @@ function StatusBadge({
 // an Issue created yet — a process bug worth flagging).
 const DRAFT_REDUNDANT_STATUSES = new Set(['Ideas', 'Backlog']);
 
+
+function RewardConfiguratorButton({
+  reward,
+  stopPropagation: shouldStop = false,
+}: {
+  reward: number;
+  stopPropagation?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  // 0–100 % of the USDC reward the user wants to convert to extra iBox
+  const [conversionPct, setConversionPct] = useState(0);
+
+  const usdcAmount = Math.round(reward * (1 - conversionPct / 100));
+  // Minimum 10% bonus is always on top; slider adds more on top of that
+  const iboxBonus = Math.round((reward * 0.1) / IBOX_PRICE_USD);
+  const iboxExtra = Math.round((reward * (conversionPct / 100)) / IBOX_PRICE_USD);
+  const iboxAmount = iboxBonus + iboxExtra;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          if (shouldStop) e.stopPropagation();
+          setOpen(true);
+        }}
+        className="cursor-pointer"
+      >
+        <Badge
+          variant="outline"
+          className="bg-ib-brand-alpha text-ib-brand border-ib-brand/30 pointer-events-none"
+        >
+          {formatReward(reward)}
+        </Badge>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent showCloseButton className="sm:max-w-xs">
+          <DialogHeader>
+            <DialogTitle className="text-center">Adjust your reward</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-6 py-2">
+            <div className="flex items-baseline justify-center gap-3">
+              <div className="text-right">
+                <span className="text-2xl font-bold tabular-nums">{usdcAmount}</span>
+                <span className="text-sm text-fd-muted-foreground ml-1">USDC</span>
+              </div>
+              <span className="text-fd-muted-foreground">+</span>
+              <div>
+                <span className="text-2xl font-bold tabular-nums">{iboxAmount}</span>
+                <span className="text-sm text-fd-muted-foreground ml-1">iBox</span>
+              </div>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={conversionPct}
+              onChange={(e) => setConversionPct(Number(e.target.value))}
+              className="w-full accent-ib-brand cursor-pointer"
+            />
+            <p className="text-xs text-fd-muted-foreground text-center m-0">
+              Slide right to receive more iBox tokens instead of USDC.
+              A minimum of 10% is always paid in iBox.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              className="w-full"
+              render={
+                <a
+                  href="https://coinmarketcap.com/currencies/intuition/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+            >
+              Read more
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 function MissionCard({ mission }: { mission: Mission }) {
   // Prefer the actual issue URL; fall back to the project-board pane
   // when GitHub didn't return a content URL (drafts have none).
@@ -523,9 +611,11 @@ function MissionCard({ mission }: { mission: Mission }) {
   return (
     <Dialog>
       <DialogTrigger
+        nativeButton={false}
         render={
-          <button
-            type="button"
+          <div
+            role="button"
+            tabIndex={0}
             aria-label={`View details for ${mission.title}`}
             className={cn(
               cardClasses('default'),
@@ -552,12 +642,7 @@ function MissionCard({ mission }: { mission: Mission }) {
               <Badge variant="outline">{mission.priority}</Badge>
             )}
             {typeof mission.reward === 'number' && (
-              <Badge
-                variant="outline"
-                className="bg-ib-brand-alpha text-ib-brand border-ib-brand/30"
-              >
-                {formatReward(mission.reward)}
-              </Badge>
+              <RewardConfiguratorButton reward={mission.reward} stopPropagation />
             )}
           </div>
         </div>
@@ -628,12 +713,7 @@ function MissionCard({ mission }: { mission: Mission }) {
                 <Badge variant="outline">{mission.priority}</Badge>
               )}
               {typeof mission.reward === 'number' && (
-                <Badge
-                  variant="outline"
-                  className="bg-ib-brand-alpha text-ib-brand border-ib-brand/30"
-                >
-                  {formatReward(mission.reward)}
-                </Badge>
+                <RewardConfiguratorButton reward={mission.reward} />
               )}
             </div>
           </div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,2 @@
+/** $TRUST token price in USD, used to convert iBox reward amounts. */
+export const IBOX_PRICE_USD = 0.06;


### PR DESCRIPTION
## Summary

- Clicking the reward badge (on a card or in the mission detail header) opens a reward configurator dialog
- Slider lets the applicant signal their preferred USDC/iBox split
- 10% of the reward in iBox is always added **on top** of the USDC amount (minimum bonus)
- Sliding right converts 0–100% of the USDC into additional iBox
- iBox amounts are calculated using the $TRUST token price (`$0.06`, sourced from `src/lib/config.ts`)
- Fixes a button-in-button HTML violation by switching the card trigger to `div[role=button]` with `nativeButton={false}`
- Extracts `IBOX_PRICE_USD` to `src/lib/config.ts` for easy updates

## Test plan

- [ ] Click reward badge on a mission card → reward configurator dialog opens (mission detail dialog does NOT open)
- [ ] Click reward badge in the mission detail header → reward configurator opens as nested dialog
- [ ] Slider at 0% (left): USDC = full reward, iBox = 10% bonus only
- [ ] Slider at 100% (right): USDC = 0, iBox = full reward converted + 10% bonus
- [ ] No console errors about button nesting or script tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)