### PR TITLE
chore: replace starter boilerplate with project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,75 @@
 # intuition.box
 
-This is a Next.js application generated with
-[Create Fumadocs](https://github.com/fuma-nama/fumadocs).
+The community hub for [Intuition Box DAO](https://intuition.box) — governance, treasury, missions, and builder ecosystem built on the [Intuition](https://intuition.systems) trust layer.
 
-Run development server:
+## Stack
+
+- **Framework:** [Next.js](https://nextjs.org) (App Router)
+- **Content:** [Fumadocs](https://fumadocs.dev) with MDX collections
+- **UI:** [@waveso/ui](https://github.com/waveso/ui) + [Tailwind CSS](https://tailwindcss.com)
+- **Data:** GitHub Projects API (missions), ICS calendar feed (events)
+
+## Getting Started
 
 ```bash
+# Clone
+git clone https://github.com/intuition-box/intuition.box.git
+cd intuition.box
+
+# Install dependencies
+npm install
+
+# Configure environment
+cp .env.example .env
+# Add your GITHUB_TOKEN to .env
+
+# Run dev server
 npm run dev
-# or
-pnpm dev
-# or
-yarn dev
 ```
 
-Open http://localhost:3000 with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) to view the site.
 
-## Explore
+## Project Structure
 
-In the project, you can see:
+```
+src/
+├── app/
+│   ├── (home)/          # Landing page, blog, missions
+│   ├── docs/            # Documentation pages
+│   └── api/search/      # Search API route
+├── components/
+│   ├── github/galaxy/   # Contributor galaxy visualization
+│   ├── events/          # Community calendar
+│   └── backgrounds/     # Visual effects (dark veil, iridescence)
+├── lib/
+│   ├── github/          # GitHub API client & data fetching
+│   ├── calendar/        # ICS calendar parsing
+│   └── source.ts        # Fumadocs content source adapter
+content/
+├── docs/                # Documentation (MDX)
+└── blog/                # Blog posts (MDX)
+```
 
-- `lib/source.ts`: Code for content source adapter, [`loader()`](https://fumadocs.dev/docs/headless/source-api) provides the interface to access your content.
-- `lib/layout.shared.tsx`: Shared options for layouts, optional but preferred to keep.
+## Key Features
 
-| Route                     | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `app/(home)`              | The route group for your landing page and other pages. |
-| `app/docs`                | The documentation layout and pages.                    |
-| `app/api/search/route.ts` | The Route Handler for search.                          |
+- **Missions Board** — GitHub Projects integration showing available bounties, applications, and rewards
+- **Contributor Galaxy** — Interactive visualization of the builder network
+- **Community Calendar** — Weekly event grid parsed from ICS feeds
+- **Documentation** — DAO governance, FAQ, and mission guides
+- **Blog** — Ecosystem updates and grant announcements
 
-### Fumadocs MDX
+## Content
 
-A `source.config.ts` config file has been included, you can customise different options like frontmatter schema.
+Documentation and blog posts live in `content/` as MDX files. See [Fumadocs docs](https://fumadocs.dev/docs/mdx) for authoring guides.
 
-Read the [Introduction](https://fumadocs.dev/docs/mdx) for further details.
+## Links
 
-## Learn More
+- [Intuition Portal](https://portal.intuition.systems)
+- [Governance Forum](https://atlas.discourse.group/c/governance/intuition-box/35)
+- [Grant Applications](https://atlas.discourse.group/c/ecosystem-development/grant-applications/36)
+- [Mission Board](https://github.com/orgs/intuition-box/projects/21)
+- [Discord](https://discord.gg/0xintuition)
 
-To learn more about Next.js and Fumadocs, take a look at the following
-resources:
+## License
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
-  features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [Fumadocs](https://fumadocs.dev) - learn about Fumadocs
+See [LICENSE](./LICENSE) for details.

--- a/source.config.ts
+++ b/source.config.ts
@@ -2,8 +2,7 @@ import { defineCollections, defineConfig, defineDocs } from 'fumadocs-mdx/config
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import { z } from 'zod';
 
-// You can customise Zod schemas for frontmatter and `meta.json` here
-// see https://fumadocs.dev/docs/mdx/collections
+// Content source configuration — see https://fumadocs.dev/docs/mdx/collections
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {


### PR DESCRIPTION
## What

Replaces the generic Fumadocs/Create Fumadocs starter README with proper project documentation.

### Changes

- **README.md** — New README covering:
  - Stack overview (Next.js, Fumadocs, @waveso/ui, Tailwind CSS)
  - Getting started guide
  - Project structure reference
  - Key features summary
  - Links to governance, grants, missions, and community
- **source.config.ts** — Replaced generic starter comment with concise reference

### Why

The current README is still the default Fumadocs scaffold ("This is a Next.js application generated with Create Fumadocs"). A proper README helps new contributors onboard faster and reflects the maturity of the project.

Closes #2